### PR TITLE
[Discover] Remove some whitespace around the Unified Histogram resize button

### DIFF
--- a/src/plugins/unified_histogram/public/layout/layout.tsx
+++ b/src/plugins/unified_histogram/public/layout/layout.tsx
@@ -275,7 +275,7 @@ export const UnifiedHistogramLayout = ({
           chart={chart}
           breakdown={breakdown}
           appendHitsCounter={appendHitsCounter}
-          appendHistogram={showFixedPanels ? <EuiSpacer size="s" /> : <EuiSpacer size="l" />}
+          appendHistogram={<EuiSpacer size="s" />}
           disableAutoFetching={disableAutoFetching}
           disableTriggers={disableTriggers}
           disabledActions={disabledActions}

--- a/src/plugins/unified_histogram/public/panels/panels_resizable.tsx
+++ b/src/plugins/unified_histogram/public/panels/panels_resizable.tsx
@@ -6,12 +6,7 @@
  * Side Public License, v 1.
  */
 
-import {
-  EuiResizableContainer,
-  useEuiTheme,
-  useGeneratedHtmlId,
-  useResizeObserver,
-} from '@elastic/eui';
+import { EuiResizableContainer, useGeneratedHtmlId, useResizeObserver } from '@elastic/eui';
 import type { ResizeTrigger } from '@elastic/eui/src/components/resizable_container/types';
 import { css } from '@emotion/react';
 import { isEqual, round } from 'lodash';
@@ -162,12 +157,6 @@ export const PanelsResizable = ({
     disableResizeWithPortalsHack();
   }, [disableResizeWithPortalsHack, resizeWithPortalsHackIsResizing]);
 
-  const { euiTheme } = useEuiTheme();
-  const buttonCss = css`
-    margin-top: -${euiTheme.size.base};
-    margin-bottom: 0;
-  `;
-
   return (
     <EuiResizableContainer
       className={className}
@@ -189,7 +178,7 @@ export const PanelsResizable = ({
             {topPanel}
           </EuiResizablePanel>
           <EuiResizableButton
-            css={[resizeWithPortalsHackButtonCss, buttonCss]}
+            css={resizeWithPortalsHackButtonCss}
             data-test-subj="unifiedHistogramResizableButton"
           />
           <EuiResizablePanel


### PR DESCRIPTION
## Summary

This PR removes some of the whitespace around the Unified Histogram resize button in Discover to add some extra space for the chart.

Before:
<img width="1816" alt="resize_handle_current" src="https://github.com/jughosta/kibana/assets/25592674/146d10dd-234c-4470-a909-2ce7b36aab73">

After:
<img width="1816" alt="resize_handle_compressed" src="https://github.com/jughosta/kibana/assets/25592674/2f9727d9-45b2-4007-8db9-b03ab3b319f3">