### PR TITLE
Total hits and histogram control touchups

### DIFF
--- a/packages/shared-ux/button_toolbar/src/buttons/toolbar_button/toolbar_button.test.tsx
+++ b/packages/shared-ux/button_toolbar/src/buttons/toolbar_button/toolbar_button.test.tsx
@@ -45,6 +45,13 @@ describe('<ToolbarButton />', () => {
       component.find('button').simulate('click');
       expect(mockHandler).toHaveBeenCalled();
     });
+
+    test('accepts an onBlur handler', () => {
+      const mockHandler = jest.fn();
+      const component = mountWithIntl(<ToolbarButton label="Create chart" onBlur={mockHandler} />);
+      component.find('button').simulate('blur');
+      expect(mockHandler).toHaveBeenCalled();
+    });
   });
 
   describe('iconButton', () => {

--- a/packages/shared-ux/button_toolbar/src/buttons/toolbar_button/toolbar_button.tsx
+++ b/packages/shared-ux/button_toolbar/src/buttons/toolbar_button/toolbar_button.tsx
@@ -23,7 +23,7 @@ type ButtonRenderStyle = 'standard' | 'iconButton';
 interface ToolbarButtonCommonProps
   extends Pick<
     EuiButtonPropsForButton,
-    'onClick' | 'iconType' | 'size' | 'data-test-subj' | 'isDisabled' | 'aria-label'
+    'onClick' | 'onBlur' | 'iconType' | 'size' | 'data-test-subj' | 'isDisabled' | 'aria-label'
   > {
   /**
    * Render style of the toolbar button

--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -9,7 +9,11 @@
 // focus states in Kibana.
 :focus {
   &:not([class^='eui']):not(.kbn-resetFocusState) {
-    @include euiFocusRing;
+    // The focus policy causes double focus rings to appear on EuiSelectableList
+    // since the focusable element does not contain a class starting with "eui".
+    &:not(.euiSelectableList__list > ul) {
+      @include euiFocusRing;
+    }
   }
 }
 

--- a/src/plugins/unified_histogram/public/chart/chart.tsx
+++ b/src/plugins/unified_histogram/public/chart/chart.tsx
@@ -277,58 +277,68 @@ export function Chart({
       responsive={false}
     >
       <EuiFlexItem grow={false} css={chartToolbarCss}>
-        <EuiFlexGroup direction="row" gutterSize="s" responsive={false} alignItems="center">
-          <EuiFlexItem grow={false}>
-            {renderCustomChartToggleActions ? (
-              renderCustomChartToggleActions()
-            ) : (
-              <IconButtonGroup
-                legend={i18n.translate('unifiedHistogram.hideChartButtongroupLegend', {
-                  defaultMessage: 'Chart visibility',
-                })}
-                buttonSize="s"
-                buttons={[
-                  {
-                    label: chartVisible
-                      ? i18n.translate('unifiedHistogram.hideChartButton', {
-                          defaultMessage: 'Hide chart',
-                        })
-                      : i18n.translate('unifiedHistogram.showChartButton', {
-                          defaultMessage: 'Show chart',
-                        }),
-                    iconType: chartVisible ? 'transitionTopOut' : 'transitionTopIn',
-                    'data-test-subj': 'unifiedHistogramToggleChartButton',
-                    onClick: toggleHideChart,
-                  },
-                ]}
-              />
-            )}
-          </EuiFlexItem>
-          {chartVisible && !isPlainRecord && !!onTimeIntervalChange && (
-            <EuiFlexItem grow={false}>
-              <TimeIntervalSelector chart={chart} onTimeIntervalChange={onTimeIntervalChange} />
-            </EuiFlexItem>
-          )}
-          <EuiFlexItem>
-            <div>
-              {chartVisible && breakdown && (
-                <BreakdownFieldSelector
-                  dataView={dataView}
-                  breakdown={breakdown}
-                  onBreakdownFieldChange={onBreakdownFieldChange}
-                />
-              )}
-              {chartVisible &&
-                currentSuggestion &&
-                allSuggestions &&
-                allSuggestions?.length > 1 && (
-                  <SuggestionSelector
-                    suggestions={allSuggestions}
-                    activeSuggestion={currentSuggestion}
-                    onSuggestionChange={onSuggestionSelectorChange}
+        <EuiFlexGroup
+          direction="row"
+          gutterSize="s"
+          responsive={false}
+          alignItems="center"
+          justifyContent="spaceBetween"
+        >
+          <EuiFlexItem grow={false} css={{ minWidth: 0 }}>
+            <EuiFlexGroup direction="row" gutterSize="s" responsive={false} alignItems="center">
+              <EuiFlexItem grow={false}>
+                {renderCustomChartToggleActions ? (
+                  renderCustomChartToggleActions()
+                ) : (
+                  <IconButtonGroup
+                    legend={i18n.translate('unifiedHistogram.hideChartButtongroupLegend', {
+                      defaultMessage: 'Chart visibility',
+                    })}
+                    buttonSize="s"
+                    buttons={[
+                      {
+                        label: chartVisible
+                          ? i18n.translate('unifiedHistogram.hideChartButton', {
+                              defaultMessage: 'Hide chart',
+                            })
+                          : i18n.translate('unifiedHistogram.showChartButton', {
+                              defaultMessage: 'Show chart',
+                            }),
+                        iconType: chartVisible ? 'transitionTopOut' : 'transitionTopIn',
+                        'data-test-subj': 'unifiedHistogramToggleChartButton',
+                        onClick: toggleHideChart,
+                      },
+                    ]}
                   />
                 )}
-            </div>
+              </EuiFlexItem>
+              {chartVisible && !isPlainRecord && !!onTimeIntervalChange && (
+                <EuiFlexItem grow={false} css={{ minWidth: 0 }}>
+                  <TimeIntervalSelector chart={chart} onTimeIntervalChange={onTimeIntervalChange} />
+                </EuiFlexItem>
+              )}
+              <EuiFlexItem grow={false} css={{ minWidth: 0 }}>
+                <div>
+                  {chartVisible && breakdown && (
+                    <BreakdownFieldSelector
+                      dataView={dataView}
+                      breakdown={breakdown}
+                      onBreakdownFieldChange={onBreakdownFieldChange}
+                    />
+                  )}
+                  {chartVisible &&
+                    currentSuggestion &&
+                    allSuggestions &&
+                    allSuggestions?.length > 1 && (
+                      <SuggestionSelector
+                        suggestions={allSuggestions}
+                        activeSuggestion={currentSuggestion}
+                        onSuggestionChange={onSuggestionSelectorChange}
+                      />
+                    )}
+                </div>
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFlexItem>
           {chartVisible && actions.length > 0 && (
             <EuiFlexItem grow={false}>

--- a/src/plugins/unified_histogram/public/chart/suggestion_selector.tsx
+++ b/src/plugins/unified_histogram/public/chart/suggestion_selector.tsx
@@ -75,6 +75,8 @@ export const SuggestionSelector = ({
       position="top"
       content={suggestionsPopoverDisabled ? undefined : activeSuggestion?.title}
       anchorProps={{ css: suggestionComboCss }}
+      display="block"
+      delay="long"
     >
       <EuiComboBox
         data-test-subj="unifiedHistogramSuggestionSelector"


### PR DESCRIPTION
This PR includes several UX touchups to the original PR:

Fix double `EuiSelectable` focus ring styles:
<img width="271" alt="focus_ring" src="https://github.com/jughosta/kibana/assets/25592674/c983a68d-6593-4941-b831-06a26268e1bc">

Fix issue where toolbar buttons get cut off on smaller screen sizes (also happened in mobile view):
<img width="880" alt="icon_cut_off" src="https://github.com/jughosta/kibana/assets/25592674/02ab1b93-a205-4400-9425-5e0bbb9685b1">

Add tooltips to toolbar buttons so users can see the full labels when truncated:
<img width="426" alt="tooltip" src="https://github.com/jughosta/kibana/assets/25592674/e43b9dd4-7ed5-4fef-b34f-5719d78045bc">

Tweak toolbar button menu designs to more closely match mockups (full-width menu items, compressed search bar, show all time interval menu items without scrolling). Add middle truncation to toolbar button menus for long values, and update search bar placeholder to "Search" to match mockups. Autofocus on toolbar button menu selectables when popover is opened (improves a11y for keyboard users):
<img width="634" alt="truncate_and_placeholder" src="https://github.com/jughosta/kibana/assets/25592674/5b5818f0-5c8e-484f-8214-5697d523dc72">
<img width="277" alt="interval_all_options" src="https://github.com/jughosta/kibana/assets/25592674/c09e1ff8-5962-49ce-9f80-af1c6af9e5bc">

Update toolbar button menu "no results" display to put message and search term on one line (the `<strong>` tag was using `display: block` when not wrapped in a `<p>` tag):
<img width="454" alt="not_found" src="https://github.com/jughosta/kibana/assets/25592674/9b194a00-3bdd-4914-9526-4f9b970931a4">

Remove extra 2 pixels below Lens suggestion selector caused by `display: inline-block`, and update tooltip delay to "long" to match the toolbar button tooltips.