### PR TITLE
Restorable state cleanup and optimizations

### DIFF
--- a/src/platform/packages/shared/kbn-restorable-state/index.ts
+++ b/src/platform/packages/shared/kbn-restorable-state/index.ts
@@ -7,4 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { createRestorableStateProvider } from './src/restorable_state_provider';
+export {
+  type RestorableStateProviderProps,
+  type RestorableStateProviderApi,
+  createRestorableStateProvider,
+} from './src/restorable_state_provider';

--- a/src/platform/packages/shared/kbn-restorable-state/src/restorable_state_provider.tsx
+++ b/src/platform/packages/shared/kbn-restorable-state/src/restorable_state_provider.tsx
@@ -98,7 +98,6 @@ export const createRestorableStateProvider = <TState extends object>() => {
             initialState={initialState}
             onInitialStateChange={onInitialStateChange}
           >
-            {/* TODO: Why is `as TProps` necessary here? */}
             <Component {...(props as TProps)} />
           </RestorableStateProvider>
         );


### PR DESCRIPTION
## Summary

This PR includes some cleanup for the restorable state package (mainly taking care of TODOs and finishing refresh support), and some optimizations to limit renders on `initialState` changes:
- Split out a `useStableFunction` utility instead of doing it inline for each function.
- Migrate `initialState` passed from the provider to a `BehaviorSubject` called `initialState$` to stabilize the reference and prevent renders in context consumers on change (originally thought it also addressed the `setTimeout` thing, but I misunderstood why that was added).
- Finish implementing `refreshInitialState` support in the `ref` API.
- Improve the types, mainly switching `initialState` to `Partial<TState>` which is more accurate.
- Stabilize some other references like `latestInitialState` to further reduce renders and optimize the `ref` API.
- Other misc cleanups like removing redundant TODOs, and extracting reusable types and utils.