### PR TITLE
More Discover tabs background search fixes

### DIFF
--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -484,6 +484,7 @@ export class SessionService {
    * @param sessionId
    */
   public restore(sessionId: string) {
+    this.storeSessionSnapshot();
     this.state.transitions.restore(sessionId);
     this.refreshSearchSessionSavedObject();
   }

--- a/src/platform/plugins/shared/data/public/search/session/session_service.ts
+++ b/src/platform/plugins/shared/data/public/search/session/session_service.ts
@@ -519,6 +519,17 @@ export class SessionService {
     }
   }
 
+  /**
+   * Resets the current search session state.
+   * Can be used to reset to a default state without clearing initialization info, such as when switching between discover tabs.
+   *
+   * This is different from {@link clear} as it does not reset initialization info set through {@link enableStorage}.
+   */
+  public reset() {
+    this.storeSessionSnapshot();
+    this.state.transitions.clear();
+  }
+
   private storeSessionSnapshot() {
     if (!this.getSessionId()) return;
     const currentState = createSessionStateContainer<TrackSearchDescriptor, TrackSearchMeta>({

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -194,13 +194,14 @@ export const useTopNavLinks = ({
     }, [
       defaultMenu,
       services,
-      onOpenInspector,
       discoverParams,
+      appId,
+      onOpenInspector,
       state,
+      dispatch,
       isEsqlMode,
       currentDataView,
       hasShareIntegration,
-      appId,
     ]);
 
   const getAppMenuAccessor = useProfileAccessor('getAppMenu');

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -248,12 +248,7 @@ export function getDataStateContainer({
     const subscription = fetch$
       .pipe(
         mergeMap(async ({ options }) => {
-          const {
-            id: currentTabId,
-            resetDefaultProfileState,
-            dataRequestParams,
-            initialInternalState,
-          } = getCurrentTab();
+          const { id: currentTabId, resetDefaultProfileState, dataRequestParams } = getCurrentTab();
           const { scopedProfilesManager$, scopedEbtManager$, currentDataView$ } =
             selectTabRuntimeState(runtimeStateManager, currentTabId);
           const scopedProfilesManager = scopedProfilesManager$.getValue();
@@ -265,10 +260,6 @@ export function getDataStateContainer({
           if (options.fetchMore && dataRequestParams.searchSessionId) {
             searchSessionId = dataRequestParams.searchSessionId;
             isSearchSessionRestored = dataRequestParams.isSearchSessionRestored;
-          } else if (!dataRequestParams.searchSessionId && initialInternalState?.searchSessionId) {
-            searchSessionId = initialInternalState.searchSessionId;
-            isSearchSessionRestored = true;
-            data.search.session.restore(searchSessionId);
           } else {
             ({ searchSessionId, isSearchSessionRestored } =
               searchSessionManager.getNextSearchSessionId());

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_search_session.test.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_search_session.test.ts
@@ -66,7 +66,7 @@ describe('DiscoverSearchSessionManager', () => {
     test('notifies about searchSessionId changes in the URL', () => {
       const emits: Array<string | null> = [];
 
-      const sub = searchSessionManager.newSearchSessionIdFromURL$.subscribe((newId) => {
+      const sub = searchSessionManager.getNewSearchSessionIdFromURL$().subscribe((newId) => {
         emits.push(newId);
       });
 

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/discover_search_session.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/discover_search_session.ts
@@ -8,7 +8,6 @@
  */
 
 import type { History, Location } from 'history';
-import type * as Rx from 'rxjs';
 import { filter } from 'rxjs';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import {
@@ -29,17 +28,18 @@ export interface DiscoverSearchSessionManagerDeps {
  * Helps with state management of search session and {@link SEARCH_SESSION_ID_QUERY_PARAM} in the URL
  */
 export class DiscoverSearchSessionManager {
-  /**
-   * Notifies about `searchSessionId` changes in the URL,
-   * skips if `searchSessionId` matches current search session id
-   */
-  readonly newSearchSessionIdFromURL$: Rx.Observable<string | null>;
-
   private readonly deps: DiscoverSearchSessionManagerDeps;
 
   constructor(deps: DiscoverSearchSessionManagerDeps) {
     this.deps = deps;
-    this.newSearchSessionIdFromURL$ = createQueryParamObservable<string>(
+  }
+
+  /**
+   * Notifies about `searchSessionId` changes in the URL,
+   * skips if `searchSessionId` matches current search session id
+   */
+  getNewSearchSessionIdFromURL$() {
+    return createQueryParamObservable<string>(
       this.deps.history,
       SEARCH_SESSION_ID_QUERY_PARAM
     ).pipe(
@@ -74,6 +74,10 @@ export class DiscoverSearchSessionManager {
     };
   }
 
+  /**
+   * Pushes the provided search session ID to the URL
+   * @param searchSessionId - the search session ID to push to the URL
+   */
   pushSearchSessionIdToURL(
     searchSessionId: string,
     { replace = true }: { replace?: boolean } = { replace: true }

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/initialize_single_tab.ts
@@ -226,7 +226,12 @@ export const initializeSingleTab: InternalStateThunkActionCreator<
       services,
     });
 
-    if (tabInitialInternalState?.searchSessionId) {
+    // Push the tab's initial search session ID to the URL if one exists,
+    // unless it should be overridden by a search session ID already in the URL
+    if (
+      tabInitialInternalState?.searchSessionId &&
+      !searchSessionManager.hasSearchSessionIdInURL()
+    ) {
       searchSessionManager.pushSearchSessionIdToURL(tabInitialInternalState.searchSessionId, {
         replace: true,
       });

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/actions/tabs.ts
@@ -279,6 +279,7 @@ export const updateTabs: InternalStateThunkActionCreator<
         await urlStateStorage.set(GLOBAL_STATE_URL_KEY, null, { replace: true });
         await urlStateStorage.set(APP_STATE_URL_KEY, null, { replace: true });
         searchSessionManager.removeSearchSessionIdFromURL({ replace: true });
+        services.data.search.session.reset();
       }
 
       dispatch(internalStateSlice.actions.discardFlyoutsOnTabChange());


### PR DESCRIPTION
## Summary

This PR make further adjustments to the background search approach for Discover tabs and hopefully resolves these issues:
- Ensure we have all the correct params when opening a background search to prevent refetching (looked like everything was good already except the time range due to mapping from `GlobalQueryStateFromUrl` to `TabStateGlobalState`).
- Ensure the search session snapshots are updated when restoring a search so they don't get lost when switching tabs.
- Isolate instances of the `newSearchSessionIdFromURL$` observable between tabs to prevent search session IDs from previous tabs triggering extra fetches when creating new tabs, which seemed to be responsible for the refetching issue when adding ES|QL tabs with background searches.
- Reset the current search session state before initializing new tabs to prevent the background search banner leaking between tabs.