### PR TITLE
perf: Add cell rendering benchmark for field formatters

### DIFF
--- a/package.json
+++ b/package.json
@@ -671,6 +671,7 @@
     "@kbn/feedback-components": "link:src/platform/packages/shared/feedback-components",
     "@kbn/feedback-plugin": "link:x-pack/platform/plugins/private/feedback",
     "@kbn/feedback-registry": "link:x-pack/platform/packages/private/feedback-registry",
+    "@kbn/field-formats-benchmarks": "link:src/platform/packages/shared/kbn-field-formats-benchmarks",
     "@kbn/field-formats-common": "link:src/platform/packages/shared/kbn-field-formats-common",
     "@kbn/field-formats-example-plugin": "link:examples/field_formats_example",
     "@kbn/field-formats-plugin": "link:src/platform/plugins/shared/field_formats",

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/README.md
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/README.md
@@ -1,0 +1,129 @@
+# Field Formatters Benchmark
+
+Benchmark tools to measure field formatter performance.
+
+## Background
+
+Kibana's field formatting has two rendering paths:
+
+- **React path**: `formatter.reactConvert(value)` returns a `ReactNode` directly
+- **HTML bridge**: `formatter.convert(value, 'html')` uses `ReactDOM.renderToStaticMarkup()` internally to convert React output to an HTML string
+
+The HTML bridge exists for legacy consumers but has overhead from React server-side rendering.
+
+## Available Benchmarks
+
+| Benchmark | Description |
+|-----------|-------------|
+| `formatters.react_vs_html` | Compares React vs HTML bridge, shows overhead percentage |
+| `formatters.html_only` | Measures HTML `convert()` only, useful for branch comparisons |
+
+## Running the Benchmarks
+
+From the Kibana root directory:
+
+```bash
+# Run all benchmarks (5 runs by default)
+node scripts/bench --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts
+
+# Run only the React vs HTML comparison
+node scripts/bench --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts --grep react_vs_html
+
+# Run only the HTML-only benchmark
+node scripts/bench --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts --grep html_only
+```
+
+### Comparing Branches
+
+Compare HTML rendering performance between two git refs:
+
+```bash
+# Compare between two branches (both must have the benchmark files)
+node scripts/bench \
+  --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts \
+  --grep html_only \
+  --left my-baseline-branch \
+  --right my-feature-branch
+```
+
+This will show a diff report with percentage changes:
+- `+5%` = right branch is 5% slower than left
+- `-5%` = right branch is 5% faster than left
+
+**Note**: Both branches must have the benchmark files. If comparing against `main` (which doesn't have the benchmarks yet), you can:
+
+1. Cherry-pick or copy the benchmark files to a baseline branch first
+2. Or run benchmarks separately on each branch and compare manually:
+
+```bash
+# On main branch
+git stash
+git checkout main
+# Copy benchmark files, run, note results
+node scripts/bench --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts --grep html_only
+
+# On feature branch  
+git checkout my-feature
+node scripts/bench --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts --grep html_only
+```
+
+### CPU Profiling
+
+Generate CPU profiles for deeper analysis:
+
+```bash
+node scripts/bench \
+  --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts \
+  --profile --open-profile
+```
+
+## Output Metrics
+
+For each formatter, the benchmark reports:
+
+| Metric | Description |
+|--------|-------------|
+| `{formatter}_react_ops_sec` | Operations per second using `reactConvert()` |
+| `{formatter}_html_ops_sec` | Operations per second using `convert('html')` |
+| `{formatter}_overhead_pct` | Percentage overhead of HTML bridge vs React |
+
+Summary metrics are also provided:
+
+- `total_react_ops_sec` - Aggregate React ops/sec across all formatters
+- `total_html_ops_sec` - Aggregate HTML ops/sec across all formatters
+- `total_overhead_pct` - Overall HTML bridge overhead percentage
+- `total_iterations` - Total number of format operations performed
+
+## Formatters Benchmarked
+
+The benchmark covers all base formatters from `baseFormatters`:
+
+- Boolean
+- Bytes
+- Color
+- Currency
+- Duration
+- GeoPoint
+- Histogram
+- IP
+- Number
+- Percent
+- RelativeDate
+- StaticLookup
+- String
+- Truncate
+- URL
+
+## Customizing the Benchmark
+
+### Adjusting Iterations
+
+Edit `ITERATIONS_PER_FORMATTER` in `sample_values.ts` to change how many times each formatter is called per run (default: 10,000).
+
+### Adding Sample Values
+
+Edit `FORMATTER_SAMPLE_DATA` in `sample_values.ts` to add or modify test values for specific formatters.
+
+### Changing Number of Runs
+
+Edit `runs` in `benchmark.config.ts` to change how many benchmark runs are performed (default: 5).

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { InitialBenchConfig } from '@kbn/bench';
+
+const config: InitialBenchConfig = {
+  name: 'field_formatters',
+  runs: 5,
+  timeout: 5 * 60_000,
+  benchmarks: [
+    {
+      kind: 'module',
+      name: 'formatters.react_vs_html',
+      description: 'Compare React field formatters vs HTML bridge performance',
+      module: require.resolve('./benchmarks/formatters.bench'),
+      compare: {
+        missing: 'skip',
+      },
+    },
+    {
+      kind: 'module',
+      name: 'formatters.html_only',
+      description: 'Benchmark HTML convert() performance only (for branch comparison)',
+      module: require.resolve('./benchmarks/html_only.bench'),
+      compare: {
+        missing: 'skip',
+      },
+    },
+    {
+      kind: 'module',
+      name: 'cell_render.react',
+      description:
+        'Benchmark cell rendering with reactConvert + React SSR (for cross-branch comparison)',
+      module: require.resolve('./benchmarks/cell_render_react.bench'),
+      compare: {
+        missing: 'skip',
+      },
+    },
+    {
+      kind: 'module',
+      name: 'cell_render.html',
+      description:
+        'Benchmark cell rendering with convert(html) + dangerouslySetInnerHTML + React SSR (for cross-branch comparison)',
+      module: require.resolve('./benchmarks/cell_render_html.bench'),
+      compare: {
+        missing: 'skip',
+      },
+    },
+  ],
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/cell_render_html.bench.ts
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/cell_render_html.bench.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import type { Serializable } from '@kbn/utility-types';
+import type { BenchmarkRunnable, BenchmarkRunContext } from '@kbn/bench';
+import type {
+  FieldFormatInstanceType,
+  FieldFormatParams,
+  FieldFormatsGetConfigFn,
+} from '@kbn/field-formats-plugin/common';
+import type { FieldFormat } from '@kbn/field-formats-plugin/common';
+import { baseFormatters } from '@kbn/field-formats-plugin/common';
+import {
+  FORMATTER_SAMPLE_DATA,
+  ITERATIONS_PER_FORMATTER,
+  generateTestValues,
+} from './sample_values';
+
+interface BenchmarkMetric {
+  value: number;
+  title: string;
+  format?: 'size' | 'duration' | 'percentage' | 'number';
+}
+
+const configDefaults: Record<string, Serializable> = {
+  'format:number:defaultPattern': '0,0.[000]',
+  'format:bytes:defaultPattern': '0,0.[0]b',
+  'format:percent:defaultPattern': '0,0.[000]%',
+  'format:currency:defaultPattern': '($0,0.[00])',
+  'format:number:defaultLocale': 'en',
+  dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
+  'dateFormat:tz': 'Browser',
+};
+
+const getConfig: FieldFormatsGetConfigFn = (key: string) => {
+  return configDefaults[key];
+};
+
+function createFormatter(
+  FormatterClass: FieldFormatInstanceType,
+  params: FieldFormatParams = {}
+): FieldFormat {
+  return new FormatterClass(params, getConfig);
+}
+
+/**
+ * Benchmarks cell rendering using convert('html') + dangerouslySetInnerHTML + ReactDOMServer.renderToString().
+ * This simulates how UnifiedDataTable rendered cells with the old HTML-based approach.
+ */
+// eslint-disable-next-line import/no-default-export
+export default async function createCellRenderHtmlBenchmark(): Promise<BenchmarkRunnable> {
+  return {
+    async run(_ctx: BenchmarkRunContext) {
+      const metrics: Record<string, number | BenchmarkMetric> = {};
+
+      let totalOps = 0;
+      let totalTimeMs = 0;
+
+      for (const sampleData of FORMATTER_SAMPLE_DATA) {
+        const FormatterClass = baseFormatters.find((f) => f.id === sampleData.id);
+
+        if (!FormatterClass) {
+          continue;
+        }
+
+        const formatter = createFormatter(
+          FormatterClass,
+          (sampleData.params || {}) as FieldFormatParams
+        );
+        const sampleValues = generateTestValues(ITERATIONS_PER_FORMATTER, sampleData.values);
+
+        // Warm up
+        for (const value of sampleData.values) {
+          const html = formatter.convert(value, 'html');
+          ReactDOMServer.renderToString(
+            React.createElement('span', { dangerouslySetInnerHTML: { __html: html } })
+          );
+        }
+
+        // Benchmark: convert('html') + dangerouslySetInnerHTML + renderToString
+        // This simulates the old cell rendering approach
+        const start = performance.now();
+        for (const value of sampleValues) {
+          const html = formatter.convert(value, 'html');
+          ReactDOMServer.renderToString(
+            React.createElement('span', { dangerouslySetInnerHTML: { __html: html } })
+          );
+        }
+        const timeMs = performance.now() - start;
+
+        totalTimeMs += timeMs;
+        totalOps += ITERATIONS_PER_FORMATTER;
+
+        const opsPerSec = Math.round(ITERATIONS_PER_FORMATTER / (timeMs / 1000));
+
+        metrics[`${sampleData.id}_ops_sec`] = {
+          value: opsPerSec,
+          title: `${sampleData.id} ops/sec`,
+          format: 'number',
+        };
+      }
+
+      // Total metrics
+      const totalOpsPerSec = Math.round(totalOps / (totalTimeMs / 1000));
+
+      metrics.total_ops_sec = {
+        value: totalOpsPerSec,
+        title: 'Total ops/sec',
+        format: 'number',
+      };
+      metrics.total_time_ms = {
+        value: Math.round(totalTimeMs),
+        title: 'Total time (ms)',
+        format: 'duration',
+      };
+
+      return { metrics };
+    },
+  };
+}

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/cell_render_react.bench.ts
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/cell_render_react.bench.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import type { Serializable } from '@kbn/utility-types';
+import type { BenchmarkRunnable, BenchmarkRunContext } from '@kbn/bench';
+import type {
+  FieldFormatInstanceType,
+  FieldFormatParams,
+  FieldFormatsGetConfigFn,
+} from '@kbn/field-formats-plugin/common';
+import type { FieldFormat } from '@kbn/field-formats-plugin/common';
+import { baseFormatters } from '@kbn/field-formats-plugin/common';
+import {
+  FORMATTER_SAMPLE_DATA,
+  ITERATIONS_PER_FORMATTER,
+  generateTestValues,
+} from './sample_values';
+
+interface BenchmarkMetric {
+  value: number;
+  title: string;
+  format?: 'size' | 'duration' | 'percentage' | 'number';
+}
+
+const configDefaults: Record<string, Serializable> = {
+  'format:number:defaultPattern': '0,0.[000]',
+  'format:bytes:defaultPattern': '0,0.[0]b',
+  'format:percent:defaultPattern': '0,0.[000]%',
+  'format:currency:defaultPattern': '($0,0.[00])',
+  'format:number:defaultLocale': 'en',
+  dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
+  'dateFormat:tz': 'Browser',
+};
+
+const getConfig: FieldFormatsGetConfigFn = (key: string) => {
+  return configDefaults[key];
+};
+
+function createFormatter(
+  FormatterClass: FieldFormatInstanceType,
+  params: FieldFormatParams = {}
+): FieldFormat {
+  return new FormatterClass(params, getConfig);
+}
+
+/**
+ * Benchmarks cell rendering using reactConvert + ReactDOMServer.renderToString().
+ * This simulates how UnifiedDataTable renders cells with the new React-based approach.
+ */
+// eslint-disable-next-line import/no-default-export
+export default async function createCellRenderReactBenchmark(): Promise<BenchmarkRunnable> {
+  return {
+    async run(_ctx: BenchmarkRunContext) {
+      const metrics: Record<string, number | BenchmarkMetric> = {};
+
+      let totalOps = 0;
+      let totalTimeMs = 0;
+
+      for (const sampleData of FORMATTER_SAMPLE_DATA) {
+        const FormatterClass = baseFormatters.find((f) => f.id === sampleData.id);
+
+        if (!FormatterClass) {
+          continue;
+        }
+
+        const formatter = createFormatter(
+          FormatterClass,
+          (sampleData.params || {}) as FieldFormatParams
+        );
+        const sampleValues = generateTestValues(ITERATIONS_PER_FORMATTER, sampleData.values);
+
+        // Warm up
+        for (const value of sampleData.values) {
+          const reactNode = formatter.reactConvert(value);
+          ReactDOMServer.renderToString(React.createElement('span', null, reactNode));
+        }
+
+        // Benchmark: reactConvert + renderToString (simulates full cell rendering)
+        const start = performance.now();
+        for (const value of sampleValues) {
+          const reactNode = formatter.reactConvert(value);
+          ReactDOMServer.renderToString(React.createElement('span', null, reactNode));
+        }
+        const timeMs = performance.now() - start;
+
+        totalTimeMs += timeMs;
+        totalOps += ITERATIONS_PER_FORMATTER;
+
+        const opsPerSec = Math.round(ITERATIONS_PER_FORMATTER / (timeMs / 1000));
+
+        metrics[`${sampleData.id}_ops_sec`] = {
+          value: opsPerSec,
+          title: `${sampleData.id} ops/sec`,
+          format: 'number',
+        };
+      }
+
+      // Total metrics
+      const totalOpsPerSec = Math.round(totalOps / (totalTimeMs / 1000));
+
+      metrics.total_ops_sec = {
+        value: totalOpsPerSec,
+        title: 'Total ops/sec',
+        format: 'number',
+      };
+      metrics.total_time_ms = {
+        value: Math.round(totalTimeMs),
+        title: 'Total time (ms)',
+        format: 'duration',
+      };
+
+      return { metrics };
+    },
+  };
+}

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/formatters.bench.ts
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/formatters.bench.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Serializable } from '@kbn/utility-types';
+import type { BenchmarkRunnable, BenchmarkRunContext } from '@kbn/bench';
+import type {
+  FieldFormatInstanceType,
+  FieldFormatParams,
+  FieldFormatsGetConfigFn,
+} from '@kbn/field-formats-plugin/common';
+import type { FieldFormat } from '@kbn/field-formats-plugin/common';
+import { baseFormatters } from '@kbn/field-formats-plugin/common';
+import {
+  FORMATTER_SAMPLE_DATA,
+  ITERATIONS_PER_FORMATTER,
+  generateTestValues,
+  type SampleValue,
+} from './sample_values';
+
+interface FormatterBenchmarkResult {
+  reactTimeMs: number;
+  htmlTimeMs: number;
+  iterations: number;
+}
+
+interface BenchmarkMetric {
+  value: number;
+  title: string;
+  format?: 'size' | 'duration' | 'percentage' | 'number';
+}
+
+interface RunResult {
+  id: string;
+  reactOpsPerSec: number;
+  htmlOpsPerSec: number;
+  overheadPct: number;
+}
+
+const configDefaults: Record<string, Serializable> = {
+  'format:number:defaultPattern': '0,0.[000]',
+  'format:bytes:defaultPattern': '0,0.[0]b',
+  'format:percent:defaultPattern': '0,0.[000]%',
+  'format:currency:defaultPattern': '($0,0.[00])',
+  'format:number:defaultLocale': 'en',
+  dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
+  'dateFormat:tz': 'Browser',
+};
+
+const getConfig: FieldFormatsGetConfigFn = (key: string) => {
+  return configDefaults[key];
+};
+
+function createFormatter(
+  FormatterClass: FieldFormatInstanceType,
+  params: FieldFormatParams = {}
+): FieldFormat {
+  return new FormatterClass(params, getConfig);
+}
+
+function benchmarkFormatter(
+  formatter: FieldFormat,
+  values: SampleValue[],
+  iterations: number
+): FormatterBenchmarkResult {
+  const testValues = generateTestValues(iterations, values);
+
+  // Warm up - run once to initialize any caches
+  for (const value of values) {
+    formatter.reactConvert(value);
+    formatter.convert(value, 'html');
+  }
+
+  // Benchmark React path
+  const reactStart = performance.now();
+  for (const value of testValues) {
+    formatter.reactConvert(value);
+  }
+  const reactTimeMs = performance.now() - reactStart;
+
+  // Benchmark HTML bridge path
+  const htmlStart = performance.now();
+  for (const value of testValues) {
+    formatter.convert(value, 'html');
+  }
+  const htmlTimeMs = performance.now() - htmlStart;
+
+  return {
+    reactTimeMs,
+    htmlTimeMs,
+    iterations,
+  };
+}
+
+function formatOps(ops: number): string {
+  if (ops >= 1_000_000) return `${(ops / 1_000_000).toFixed(2)}M`;
+  if (ops >= 1_000) return `${(ops / 1_000).toFixed(0)}K`;
+  return ops.toFixed(0);
+}
+
+function printSummary(results: RunResult[], totalOverheadPct: number): void {
+  const sorted = [...results].sort((a, b) => b.overheadPct - a.overheadPct);
+
+  const reactWins = sorted.filter((r) => r.overheadPct > 5);
+  const htmlWins = sorted.filter((r) => r.overheadPct < -5);
+  const similar = sorted.filter((r) => r.overheadPct >= -5 && r.overheadPct <= 5);
+
+  /* eslint-disable no-console */
+  console.log('\n' + '='.repeat(70));
+  console.log('FIELD FORMATTERS BENCHMARK SUMMARY');
+  console.log('='.repeat(70));
+
+  console.log(
+    `\nOverall: HTML bridge is ${
+      totalOverheadPct > 0 ? 'SLOWER' : 'FASTER'
+    } than React by ${Math.abs(totalOverheadPct).toFixed(1)}%\n`
+  );
+
+  if (reactWins.length > 0) {
+    console.log('REACT IS FASTER (use reactConvert):');
+    console.log('-'.repeat(70));
+    for (const r of reactWins) {
+      const sign = '+';
+      const pct = r.overheadPct.toFixed(0).padStart(3);
+      console.log(
+        `  ${r.id.padEnd(16)} ${sign}${pct}% overhead | React: ${formatOps(
+          r.reactOpsPerSec
+        ).padStart(7)} ops/s | HTML: ${formatOps(r.htmlOpsPerSec).padStart(7)} ops/s`
+      );
+    }
+  }
+
+  if (htmlWins.length > 0) {
+    console.log('\nHTML IS FASTER (text-only formatters):');
+    console.log('-'.repeat(70));
+    for (const r of htmlWins) {
+      const pct = Math.abs(r.overheadPct).toFixed(0).padStart(3);
+      console.log(
+        `  ${r.id.padEnd(16)} -${pct}% faster    | React: ${formatOps(r.reactOpsPerSec).padStart(
+          7
+        )} ops/s | HTML: ${formatOps(r.htmlOpsPerSec).padStart(7)} ops/s`
+      );
+    }
+  }
+
+  if (similar.length > 0) {
+    console.log('\nSIMILAR PERFORMANCE (<5% difference):');
+    console.log('-'.repeat(70));
+    for (const r of similar) {
+      const pct = r.overheadPct.toFixed(1).padStart(5);
+      console.log(
+        `  ${r.id.padEnd(16)}  ${pct}%          | React: ${formatOps(r.reactOpsPerSec).padStart(
+          7
+        )} ops/s | HTML: ${formatOps(r.htmlOpsPerSec).padStart(7)} ops/s`
+      );
+    }
+  }
+
+  console.log('\n' + '='.repeat(70) + '\n');
+  /* eslint-enable no-console */
+}
+
+// Accumulate results across runs for final summary
+const allRunResults: RunResult[][] = [];
+let totalOverheadPcts: number[] = [];
+
+// eslint-disable-next-line import/no-default-export
+export default async function createFormattersBenchmark(): Promise<BenchmarkRunnable> {
+  return {
+    async beforeAll() {
+      // Reset accumulators
+      allRunResults.length = 0;
+      totalOverheadPcts = [];
+    },
+
+    async run(_ctx: BenchmarkRunContext) {
+      const metrics: Record<string, number | BenchmarkMetric> = {};
+      const runResults: RunResult[] = [];
+
+      let totalReactTimeMs = 0;
+      let totalHtmlTimeMs = 0;
+      let totalIterations = 0;
+
+      for (const sampleData of FORMATTER_SAMPLE_DATA) {
+        const FormatterClass = baseFormatters.find((f) => f.id === sampleData.id);
+
+        if (!FormatterClass) {
+          continue;
+        }
+
+        const formatter = createFormatter(
+          FormatterClass,
+          (sampleData.params || {}) as FieldFormatParams
+        );
+        const result = benchmarkFormatter(formatter, sampleData.values, ITERATIONS_PER_FORMATTER);
+
+        totalReactTimeMs += result.reactTimeMs;
+        totalHtmlTimeMs += result.htmlTimeMs;
+        totalIterations += result.iterations;
+
+        const reactOpsPerSec = Math.round(result.iterations / (result.reactTimeMs / 1000));
+        const htmlOpsPerSec = Math.round(result.iterations / (result.htmlTimeMs / 1000));
+        const overheadPct = ((result.htmlTimeMs - result.reactTimeMs) / result.reactTimeMs) * 100;
+
+        runResults.push({
+          id: sampleData.id,
+          reactOpsPerSec,
+          htmlOpsPerSec,
+          overheadPct,
+        });
+
+        metrics[`${sampleData.id}_overhead_pct`] = {
+          value: Math.round(overheadPct * 100) / 100,
+          title: `${sampleData.id} HTML overhead %`,
+          format: 'percentage',
+        };
+      }
+
+      // Calculate totals for this run
+      const totalReactOpsPerSec = Math.round(totalIterations / (totalReactTimeMs / 1000));
+      const totalHtmlOpsPerSec = Math.round(totalIterations / (totalHtmlTimeMs / 1000));
+      const totalOverheadPct = ((totalHtmlTimeMs - totalReactTimeMs) / totalReactTimeMs) * 100;
+
+      // Store for final aggregation
+      allRunResults.push(runResults);
+      totalOverheadPcts.push(totalOverheadPct);
+
+      // Add summary metrics for @kbn/bench reporting
+      metrics.total_react_ops_sec = {
+        value: totalReactOpsPerSec,
+        title: 'Total React ops/sec',
+        format: 'number',
+      };
+      metrics.total_html_ops_sec = {
+        value: totalHtmlOpsPerSec,
+        title: 'Total HTML ops/sec',
+        format: 'number',
+      };
+      metrics.total_overhead_pct = {
+        value: Math.round(totalOverheadPct * 100) / 100,
+        title: 'Total HTML overhead %',
+        format: 'percentage',
+      };
+      metrics.total_iterations = {
+        value: totalIterations,
+        title: 'Total iterations',
+        format: 'number',
+      };
+
+      return { metrics };
+    },
+
+    async afterAll() {
+      if (allRunResults.length === 0) return;
+
+      // Aggregate results across all runs
+      const formatterIds = allRunResults[0].map((r) => r.id);
+      const aggregated: RunResult[] = formatterIds.map((id) => {
+        const runsForFormatter = allRunResults.map((run) => run.find((r) => r.id === id)!);
+
+        const avgReactOps =
+          runsForFormatter.reduce((sum, r) => sum + r.reactOpsPerSec, 0) / runsForFormatter.length;
+        const avgHtmlOps =
+          runsForFormatter.reduce((sum, r) => sum + r.htmlOpsPerSec, 0) / runsForFormatter.length;
+        const avgOverhead =
+          runsForFormatter.reduce((sum, r) => sum + r.overheadPct, 0) / runsForFormatter.length;
+
+        return {
+          id,
+          reactOpsPerSec: Math.round(avgReactOps),
+          htmlOpsPerSec: Math.round(avgHtmlOps),
+          overheadPct: avgOverhead,
+        };
+      });
+
+      const avgTotalOverhead =
+        totalOverheadPcts.reduce((sum, v) => sum + v, 0) / totalOverheadPcts.length;
+
+      // Print single aggregated summary
+      printSummary(aggregated, avgTotalOverhead);
+    },
+  };
+}

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/html_only.bench.ts
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/html_only.bench.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Serializable } from '@kbn/utility-types';
+import type { BenchmarkRunnable, BenchmarkRunContext } from '@kbn/bench';
+import type {
+  FieldFormatInstanceType,
+  FieldFormatParams,
+  FieldFormatsGetConfigFn,
+} from '@kbn/field-formats-plugin/common';
+import type { FieldFormat } from '@kbn/field-formats-plugin/common';
+import { baseFormatters } from '@kbn/field-formats-plugin/common';
+import {
+  FORMATTER_SAMPLE_DATA,
+  ITERATIONS_PER_FORMATTER,
+  generateTestValues,
+} from './sample_values';
+
+interface BenchmarkMetric {
+  value: number;
+  title: string;
+  format?: 'size' | 'duration' | 'percentage' | 'number';
+}
+
+const configDefaults: Record<string, Serializable> = {
+  'format:number:defaultPattern': '0,0.[000]',
+  'format:bytes:defaultPattern': '0,0.[0]b',
+  'format:percent:defaultPattern': '0,0.[000]%',
+  'format:currency:defaultPattern': '($0,0.[00])',
+  'format:number:defaultLocale': 'en',
+  dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
+  'dateFormat:tz': 'Browser',
+};
+
+const getConfig: FieldFormatsGetConfigFn = (key: string) => {
+  return configDefaults[key];
+};
+
+function createFormatter(
+  FormatterClass: FieldFormatInstanceType,
+  params: FieldFormatParams = {}
+): FieldFormat {
+  return new FormatterClass(params, getConfig);
+}
+
+// eslint-disable-next-line import/no-default-export
+export default async function createHtmlOnlyBenchmark(): Promise<BenchmarkRunnable> {
+  return {
+    async run(_ctx: BenchmarkRunContext) {
+      const metrics: Record<string, number | BenchmarkMetric> = {};
+
+      let totalOps = 0;
+      let totalTimeMs = 0;
+
+      for (const sampleData of FORMATTER_SAMPLE_DATA) {
+        const FormatterClass = baseFormatters.find((f) => f.id === sampleData.id);
+
+        if (!FormatterClass) {
+          continue;
+        }
+
+        const formatter = createFormatter(
+          FormatterClass,
+          (sampleData.params || {}) as FieldFormatParams
+        );
+        const sampleValues = generateTestValues(ITERATIONS_PER_FORMATTER, sampleData.values);
+
+        // Warm up
+        for (const value of sampleData.values) {
+          formatter.convert(value, 'html');
+        }
+
+        // Benchmark HTML path only
+        const start = performance.now();
+        for (const value of sampleValues) {
+          formatter.convert(value, 'html');
+        }
+        const timeMs = performance.now() - start;
+
+        totalTimeMs += timeMs;
+        totalOps += ITERATIONS_PER_FORMATTER;
+
+        const opsPerSec = Math.round(ITERATIONS_PER_FORMATTER / (timeMs / 1000));
+
+        metrics[`${sampleData.id}_ops_sec`] = {
+          value: opsPerSec,
+          title: `${sampleData.id} ops/sec`,
+          format: 'number',
+        };
+      }
+
+      // Total metrics
+      const totalOpsPerSec = Math.round(totalOps / (totalTimeMs / 1000));
+
+      metrics.total_ops_sec = {
+        value: totalOpsPerSec,
+        title: 'Total ops/sec',
+        format: 'number',
+      };
+      metrics.total_time_ms = {
+        value: Math.round(totalTimeMs),
+        title: 'Total time (ms)',
+        format: 'duration',
+      };
+
+      return { metrics };
+    },
+  };
+}

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/sample_values.ts
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/benchmarks/sample_values.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FIELD_FORMAT_IDS } from '@kbn/field-formats-plugin/common';
+
+export type SampleValue = unknown;
+
+interface FormatterSampleData {
+  id: string;
+  values: SampleValue[];
+  params?: Record<string, unknown>;
+}
+
+export const ITERATIONS_PER_FORMATTER = 10000;
+
+export const FORMATTER_SAMPLE_DATA: FormatterSampleData[] = [
+  {
+    id: FIELD_FORMAT_IDS.BOOLEAN,
+    values: [true, false, 'yes', 'no', 'true', 'false', 1, 0, null, undefined],
+  },
+  {
+    id: FIELD_FORMAT_IDS.BYTES,
+    values: [0, 1024, 1048576, 1073741824, 1.5, 0.001, null, undefined, NaN, Infinity, -Infinity],
+  },
+  {
+    id: FIELD_FORMAT_IDS.COLOR,
+    values: ['error', 'warning', 'success', 'info', 50, 100, 200, true, false, null],
+    params: {
+      fieldType: 'string',
+      colors: [
+        { regex: 'error', text: '#fff', background: '#ff0000' },
+        { regex: 'warning', text: '#000', background: '#ffff00' },
+        { regex: 'success', text: '#fff', background: '#00ff00' },
+      ],
+    },
+  },
+  {
+    id: FIELD_FORMAT_IDS.CURRENCY,
+    values: [0, 1, 100, 1000, 10000, 99.99, 1234.56, -50, null, undefined],
+  },
+  {
+    id: FIELD_FORMAT_IDS.DURATION,
+    values: [0, 1000, 60000, 3600000, 86400000, 500, 1500, null, undefined],
+    params: {
+      inputFormat: 'milliseconds',
+      outputFormat: 'humanizePrecise',
+      outputPrecision: 2,
+    },
+  },
+  {
+    id: FIELD_FORMAT_IDS.GEO_POINT,
+    values: [
+      { lat: 40.7128, lon: -74.006 },
+      { lat: 51.5074, lon: -0.1278 },
+      { lat: 35.6762, lon: 139.6503 },
+      '40.7128,-74.0060',
+      [40.7128, -74.006],
+      null,
+      undefined,
+    ],
+  },
+  {
+    id: FIELD_FORMAT_IDS.HISTOGRAM,
+    values: [
+      { values: [1, 2, 3], counts: [10, 20, 30] },
+      { values: [0.5, 1.5, 2.5], counts: [5, 15, 25] },
+      null,
+      undefined,
+    ],
+  },
+  {
+    id: FIELD_FORMAT_IDS.IP,
+    values: [
+      2130706433, // 127.0.0.1
+      3232235777, // 192.168.1.1
+      167772161, // 10.0.0.1
+      0,
+      4294967295, // 255.255.255.255
+      '192.168.1.1',
+      null,
+      undefined,
+    ],
+  },
+  {
+    id: FIELD_FORMAT_IDS.NUMBER,
+    values: [0, 1, -1, 100, 1000, 1000000, 0.5, 0.123456789, NaN, Infinity, -Infinity, null],
+  },
+  {
+    id: FIELD_FORMAT_IDS.PERCENT,
+    values: [0, 0.5, 1, 0.01, 0.999, 1.5, -0.25, null, undefined],
+  },
+  {
+    id: FIELD_FORMAT_IDS.RELATIVE_DATE,
+    values: [
+      Date.now(),
+      Date.now() - 60000,
+      Date.now() - 3600000,
+      Date.now() - 86400000,
+      Date.now() + 86400000,
+      null,
+      undefined,
+    ],
+  },
+  {
+    id: FIELD_FORMAT_IDS.STATIC_LOOKUP,
+    values: ['key1', 'key2', 'key3', 'unknown', '', null, undefined],
+    params: {
+      lookupEntries: [
+        { key: 'key1', value: 'Value One' },
+        { key: 'key2', value: 'Value Two' },
+        { key: 'key3', value: 'Value Three' },
+      ],
+      unknownKeyValue: 'Unknown',
+    },
+  },
+  {
+    id: FIELD_FORMAT_IDS.STRING,
+    values: [
+      'hello world',
+      'UPPERCASE',
+      'MixedCase',
+      'foo.bar.baz.qux',
+      'SGVsbG8gV29ybGQ=', // base64
+      'hello%20world', // url encoded
+      '',
+      null,
+      undefined,
+    ],
+  },
+  {
+    id: FIELD_FORMAT_IDS.TRUNCATE,
+    values: [
+      'short',
+      'this is a much longer string that will be truncated',
+      'a'.repeat(100),
+      'a'.repeat(500),
+      '',
+      null,
+      undefined,
+    ],
+    params: {
+      fieldLength: 20,
+    },
+  },
+  {
+    id: FIELD_FORMAT_IDS.URL,
+    values: [
+      'https://example.com',
+      'https://elastic.co/guide/en/kibana',
+      'http://localhost:5601/app/discover',
+      '#/discover',
+      '../app/kibana',
+      '/app/kibana',
+      '',
+      null,
+      undefined,
+    ],
+    params: {
+      urlTemplate: '{{rawValue}}',
+      labelTemplate: '{{value}}',
+    },
+  },
+];
+
+export function generateTestValues(count: number, baseValues: SampleValue[]): SampleValue[] {
+  const result: SampleValue[] = [];
+  for (let i = 0; i < count; i++) {
+    result.push(baseValues[i % baseValues.length]);
+  }
+  return result;
+}

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/kibana.jsonc
@@ -1,0 +1,10 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/field-formats-benchmarks",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "private",
+  "description": "Benchmarks for field formatters performance"
+}

--- a/src/platform/packages/shared/kbn-field-formats-benchmarks/tsconfig.json
+++ b/src/platform/packages/shared/kbn-field-formats-benchmarks/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@kbn/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "**/*"
+  ],
+  "kbn_references": [
+    "@kbn/bench",
+    "@kbn/field-formats-plugin",
+    "@kbn/utility-types"
+  ],
+  "exclude": [
+    "target/**/*"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1250,6 +1250,8 @@
       "@kbn/feedback-plugin/*": ["x-pack/platform/plugins/private/feedback/*"],
       "@kbn/feedback-registry": ["x-pack/platform/packages/private/feedback-registry"],
       "@kbn/feedback-registry/*": ["x-pack/platform/packages/private/feedback-registry/*"],
+      "@kbn/field-formats-benchmarks": ["src/platform/packages/shared/kbn-field-formats-benchmarks"],
+      "@kbn/field-formats-benchmarks/*": ["src/platform/packages/shared/kbn-field-formats-benchmarks/*"],
       "@kbn/field-formats-common": ["src/platform/packages/shared/kbn-field-formats-common"],
       "@kbn/field-formats-common/*": ["src/platform/packages/shared/kbn-field-formats-common/*"],
       "@kbn/field-formats-example-plugin": ["examples/field_formats_example"],


### PR DESCRIPTION
## Summary

Adds benchmarks to compare cell rendering performance between two field formatter approaches:

- **`cell_render.react`**: Uses `formatter.reactConvert(value)` + `ReactDOMServer.renderToString()` (new approach)
- **`cell_render.html`**: Uses `formatter.convert(value, 'html')` + `dangerouslySetInnerHTML` + `ReactDOMServer.renderToString()` (old approach)

## Benchmark Results

### Cross-Branch Comparison

| Formatter | reactConvert (new) | HTML + dangerouslySetInnerHTML (old) | Difference |
|-----------|-------------------|--------------------------------------|------------|
| boolean | 679K ops/sec | 716K ops/sec | Old is 5% faster |
| bytes | 516K ops/sec | 493K ops/sec | **New is 5% faster** |
| color | 553K ops/sec | 470K ops/sec | **New is 18% faster** |
| currency | 467K ops/sec | 459K ops/sec | ~Same |
| duration | 550K ops/sec | 528K ops/sec | **New is 4% faster** |
| geo_point | 386K ops/sec | 647K ops/sec | Old is 68% faster |
| histogram | 585K ops/sec | 688K ops/sec | Old is 18% faster |
| ip | 727K ops/sec | 800K ops/sec | Old is 10% faster |
| number | 564K ops/sec | 471K ops/sec | **New is 20% faster** |
| percent | 529K ops/sec | 504K ops/sec | **New is 5% faster** |
| relative_date | 255K ops/sec | 242K ops/sec | **New is 5% faster** |
| static_lookup | 725K ops/sec | 744K ops/sec | Old is 3% faster |
| string | 745K ops/sec | 816K ops/sec | Old is 10% faster |
| truncate | 679K ops/sec | 700K ops/sec | Old is 3% faster |
| url | 436K ops/sec | 656K ops/sec | Old is 50% faster |
| **Total** | **516K ops/sec** | **537K ops/sec** | **Old is 4% faster** |

### Key Findings

- **Overall**: Old HTML approach is only **~4% faster** than the new `reactConvert` approach
- **reactConvert wins** (6 formatters): bytes, color, duration, number, percent, relative_date
- **HTML wins** (8 formatters): boolean, geo_point, histogram, ip, static_lookup, string, truncate, url
- **Similar performance**: currency

The biggest outliers where the old approach is faster are `geo_point` (68% faster) and `url` (50% faster).

## How to Run

```bash
# Run reactConvert benchmark (on branch with reactConvert) https://github.com/jughosta/kibana/pull/22
node scripts/bench --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts --grep cell_render.react

# Run HTML benchmark (on branch with old HTML convert) https://github.com/jughosta/kibana/pull/23
node scripts/bench --config src/platform/packages/shared/kbn-field-formats-benchmarks/benchmark.config.ts --grep cell_render.html
```